### PR TITLE
Fix link

### DIFF
--- a/pages/hacktoberfest.html
+++ b/pages/hacktoberfest.html
@@ -25,7 +25,7 @@ callout: |
         <div class="key-point color--texas-rose">
             <div class="count">{% include icon_pull-request.html %}</div>
             <div class="title"><a href="https://github.com/meedan/check/issues?q=is%3Aissue+is%3Aopen+label%3Ahacktoberfest">Create a<br /> pull request</a></div>
-            <div class="description">Contribute a <a href="https://hacktoberfest.digitalocean.com/details/#quality">valid pull request</a> for any of our open source projects during the month of October. <br/><a href="https://github.com/meedan/check/issues?q=is%3Aissue+is%3Aopen+label%3Ahacktoberfest" class="button transparent no-bottom-margin">Get started ↗</a></div>
+            <div class="description">Contribute a <a href="https://hacktoberfest.digitalocean.com/resources/participation">valid pull request</a> for any of our open source projects during the month of October. <br/><a href="https://github.com/meedan/check/issues?q=is%3Aissue+is%3Aopen+label%3Ahacktoberfest" class="button transparent no-bottom-margin">Get started ↗</a></div>
         </div>
         <div class="key-point color--coral">
             <div class="count">{% include icon_tshirt.html %}</div>


### PR DESCRIPTION
The old link on https://meedan.com/hacktoberfest (underlined `valid pull request`) leads to 404.

The new link shows the rules on digitalocean.com (https://hacktoberfest.digitalocean.com/resources/participation).